### PR TITLE
Fix delete pushToken logic

### DIFF
--- a/ChannelIO/Source/ChannelIO/ChannelIO.swift
+++ b/ChannelIO/Source/ChannelIO/ChannelIO.swift
@@ -229,10 +229,15 @@ public final class ChannelIO: NSObject {
    */
   @objc
   public class func shutdown() {
-    dispatch {
-      ChannelIO.reset()
-    }
     AppManager.unregisterToken()
+      .observeOn(MainScheduler.instance)
+      .subscribe(onNext: { _ in
+        dlog("shutdown success")
+        ChannelIO.reset()
+      }, onError: { _ in
+        dlog("shutdown fail")
+        ChannelIO.reset()
+      }).disposed(by: self.disposeBag)
   }
     
   /**

--- a/ChannelIO/Source/Managers/AppManager.swift
+++ b/ChannelIO/Source/Managers/AppManager.swift
@@ -35,14 +35,8 @@ struct AppManager {
     return PluginPromise.sendPushAck(chatId: userChatId)
   }
   
-  static func unregisterToken() {
-    PluginPromise.unregisterPushToken()
-      .observeOn(MainScheduler.instance)
-      .subscribe(onNext: { _ in
-        dlog("shutdown success")
-      }, onError: { (error) in
-        dlog("shutdown fail")
-      }).disposed(by: disposeBag)
+  static func unregisterToken() -> Observable<Any?> {
+    return PluginPromise.unregisterPushToken()
   }
   
   static func checkVersion() -> Observable<Any?> {

--- a/ChannelIO/Source/Promises/PluginPromise.swift
+++ b/ChannelIO/Source/Promises/PluginPromise.swift
@@ -60,18 +60,14 @@ struct PluginPromise {
       let req = Alamofire
         .request(RestRouter.UnregisterToken(key))
         .validate(statusCode: 200..<300)
-        .responseJSON(completionHandler: { response in
-          switch response.result {
-          case .success:
+        .response { response in
+          if let error = response.error {
+            subscriber.onError(ChannelError.serverError(msg: error.localizedDescription))
+          } else {
             subscriber.onNext(nil)
             subscriber.onCompleted()
-          case .failure(let error):
-            subscriber.onError(ChannelError.serverError(msg:
-              error.localizedDescription
-            ))
           }
-        })
-      
+        }
       return Disposables.create {
         req.cancel()
       }


### PR DESCRIPTION
1. status 200으로 오면 result 가 success이든 fail이든 상관없이 핸들링 안해도된다고 하여, 200이 아닌 경우에 대해서만 에러핸들링 하게 수정하였습니다.
2. x-session이 delete token request를 보내기 전에 channelio.reset에서 사라져서, 순서를 변경하였습니다.