### PR TITLE
Add description to ChannelPluginCompletionStatus

### DIFF
--- a/ChannelIO.xcodeproj/project.pbxproj
+++ b/ChannelIO.xcodeproj/project.pbxproj
@@ -529,6 +529,7 @@
 		9CF1098523FA7E5800D42D03 /* MiddlewareModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CF1098323FA7E5800D42D03 /* MiddlewareModel.swift */; };
 		9CF1098623FA7E5800D42D03 /* Middlewares.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CF1098423FA7E5800D42D03 /* Middlewares.swift */; };
 		9CF1098823FA7F1200D42D03 /* MarketingActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CF1098723FA7F1200D42D03 /* MarketingActions.swift */; };
+		EF83CE6724B75ED900927679 /* UIStatetests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF83CE6624B75ED900927679 /* UIStatetests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -1082,6 +1083,7 @@
 		9CF1098323FA7E5800D42D03 /* MiddlewareModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MiddlewareModel.swift; sourceTree = "<group>"; };
 		9CF1098423FA7E5800D42D03 /* Middlewares.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Middlewares.swift; sourceTree = "<group>"; };
 		9CF1098723FA7F1200D42D03 /* MarketingActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarketingActions.swift; sourceTree = "<group>"; };
+		EF83CE6624B75ED900927679 /* UIStatetests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIStatetests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1639,6 +1641,7 @@
 				650D7C3C1E7254B2007DE358 /* ManagersStateTests.swift */,
 				650D7C3E1E7254C9007DE358 /* UserChatsStateTests.swift */,
 				650D7C401E725559007DE358 /* SessionsStateTests.swift */,
+				EF83CE6624B75ED900927679 /* UIStatetests.swift */,
 			);
 			name = States;
 			sourceTree = "<group>";
@@ -2929,6 +2932,7 @@
 				650D7C451E72568C007DE358 /* ManagersReducerTests.swift in Sources */,
 				650D7C351E724AD7007DE358 /* LocalMessageFactorTests.swift in Sources */,
 				1469AF9B1E2F6CF9000A8675 /* UserChatTests.swift in Sources */,
+				EF83CE6724B75ED900927679 /* UIStatetests.swift in Sources */,
 				65C4A75F1E49AC78006D7CD5 /* UserChatPromiseTests.swift in Sources */,
 				225B05FE1E4EDA14001DE109 /* GuestTests.swift in Sources */,
 				22634860209DC83C0072801B /* ChannelIOTests.swift in Sources */,

--- a/ChannelIO/Source/States/UIState.swift
+++ b/ChannelIO/Source/States/UIState.swift
@@ -28,7 +28,7 @@ struct UIState: StateType {
  *    - accessDeined: accces to ChannelPlugin server denied
  */
 @objc
-public enum ChannelPluginCompletionStatus : Int {
+public enum ChannelPluginCompletionStatus : Int, CustomStringConvertible {
   case success
   case notInitialized
   case networkTimeout
@@ -37,6 +37,19 @@ public enum ChannelPluginCompletionStatus : Int {
   case requirePayment
   case accessDenied
   case unknown
+    
+  public var description: String {
+    switch self {
+    case .success: return "success"
+    case .notInitialized: return "notInitialized"
+    case .networkTimeout: return "networkTimeout"
+    case .notAvailableVersion: return "notAvailableVersion"
+    case .serviceUnderConstruction: return "serviceUnderConstruction"
+    case .requirePayment: return "requirePayment"
+    case .accessDenied: return "accessDenied"
+    case .unknown: return "unknown"
+    }
+  }
 }
 
 struct BootState: StateType {

--- a/ChannelIOTests/UIStatetests.swift
+++ b/ChannelIOTests/UIStatetests.swift
@@ -1,0 +1,29 @@
+//
+//  UIStatetests.swift
+//  ChannelIOTests
+//
+//  Created by Yusuke Konishi on 2020/07/09.
+//  Copyright © 2020 ZOYI. All rights reserved.
+//
+
+import Quick
+import Nimble
+
+@testable import ChannelIO
+
+class UIStateTests: QuickSpec {
+  override func spec() {
+    describe("description") {
+      it("return valid value") {
+        expect(ChannelPluginCompletionStatus.success.description).to(equal("success"))
+        expect(ChannelPluginCompletionStatus.notInitialized.description).to(equal("notInitialized"))
+        expect(ChannelPluginCompletionStatus.networkTimeout.description).to(equal("networkTimeout"))
+        expect(ChannelPluginCompletionStatus.notAvailableVersion.description).to(equal("notAvailableVersion"))
+        expect(ChannelPluginCompletionStatus.serviceUnderConstruction.description).to(equal("serviceUnderConstruction"))
+        expect(ChannelPluginCompletionStatus.requirePayment.description).to(equal("requirePayment"))
+        expect(ChannelPluginCompletionStatus.accessDenied.description).to(equal("accessDenied"))
+        expect(ChannelPluginCompletionStatus.unknown.description).to(equal("unknown"))
+      }
+    }
+  }
+}

--- a/Example/Swift_Example/Channel Plugin Sample/UserViewController.swift
+++ b/Example/Swift_Example/Channel Plugin Sample/UserViewController.swift
@@ -49,6 +49,7 @@ class UserViewController : UIViewController {
       case .success:
         break
       default:
+        print("failed to boot: status = \(completion.description)")
         break
       }
     }


### PR DESCRIPTION
## Overview

Added `description` to `ChannelPluginCompletionStatus `

`ChannelPluginCompletionStatus` is int enum. If the plugin user wants to  show log when Channel IO fails to boot, they have to convert enum to string by themselves.